### PR TITLE
Fix system instruction injection and demo script

### DIFF
--- a/demo/example.py
+++ b/demo/example.py
@@ -5,11 +5,11 @@ from rica.connector import transformers_adapter as tf
 from rica.server import RiCA
 
 # 1. Create the RiCA application instance first.
-app = RiCA()
+app = RiCA("demo.sys")
 
 
 # 2. Register tools with the application instance.
-@app.register("sys.python.exec", background=False, timeout=5000)
+@app.route("/exec", background=False, timeout=5000)
 async def _sys_python_exec(input_):
     """
     A tool to execute a single line of Python code.
@@ -32,7 +32,7 @@ async def _sys_python_exec(input_):
 
 
 # 3. Create the ReasoningThread, passing the app instance to it.
-rt = tf.ReasoningThread(app, model_name="google/gemma-3-1b-it")
+rt = tf.TransformersReasoningThread(model_name="gpt2")
 
 
 # 4. Register callbacks.
@@ -63,12 +63,14 @@ async def main():
 
     # 5. Start the reasoning thread. It will initialize the model and wait for input.
     # The `run()` call here is important to start the loop, even before first insert.
+    await rt.initialize()
+    await rt.install(app)
     rt.run()
     # Initially, it will pause itself waiting for input.
 
     # 6. Insert the initial user prompt. The adapter will format it correctly.
     await rt.insert(
-        "Please calculate 123*456 using sys.python.exec. "
+        "Please calculate 123*456 using demo.sys/exec. "
         "Think step-by-step about what you need to do, and then use the "
         "rica.response tool to give me the final answer."
     )


### PR DESCRIPTION
This commit fixes an issue where the system instructions were not being injected correctly. The `insert` method in the `transformers_adapter` is updated to ensure the system prompt is injected before the user's input.

This commit also includes several fixes to the demo script to make it runnable and to align it with the library's API. These changes were necessary to test and verify the primary fix.

Changes:
- Modified `rica/connector/transformers_adapter.py` to correctly inject the system prompt.
- Fixed `demo/example.py` to:
  - Use the correct `RiCA` constructor.
  - Use the `@app.route` decorator instead of the non-existent `@app.register`.
  - Use the correct `TransformersReasoningThread` class.
  - Correctly initialize the reasoning thread and install the app.
- Changed the default model to `gpt2` to allow the demo to run without requiring access to a gated model.