### PR TITLE
feat: Robust tool tag detection using state tracking index

### DIFF
--- a/rica/adapters/transformers_adapter.py
+++ b/rica/adapters/transformers_adapter.py
@@ -207,6 +207,7 @@ class ReasoningThread(ReasoningThreadBase):
             async with self._apps_lock:
                 system_prompt = await _rica_prompt(self._apps, self.model_name, self.model_modal)
             self._context = system_prompt + self._context
+            self._last_processed_index += len(system_prompt)
             self._prompt_injected = True
 
     async def _run_loop(self):

--- a/tests/core/test_reasoning_thread.py
+++ b/tests/core/test_reasoning_thread.py
@@ -76,13 +76,16 @@ async def test_xml_parsing_robustness():
 
     # Test malformed XML that regex should recover
     # Missing quotes around attributes, slightly broken tag
+    # Reset context and processed index for new test case
     thread._context = '<rica package="test.pkg" route="/echo">{"msg": "recovered"}</rica>'
+    thread._last_processed_index = 0
     executed, result = await thread._detect_and_execute_tool_tail()
     assert executed
     assert '{"msg": "recovered"}' in result
 
     # Test completely invalid XML
     thread._context = "<rica broken>...</rica>"
+    thread._last_processed_index = 0
     executed, result = await thread._detect_and_execute_tool_tail()
     # Should return True (detected) but result contains error message
     assert executed


### PR DESCRIPTION
- Added `_last_processed_index` to `ReasoningThreadBase` to track processed context.
- Updated `_detect_and_execute_tool_tail` to scan only new content.
- Updated `transformers_adapter.py` to skip system prompt scanning.
- Fixed unit tests to respect new state tracking logic.
- Implemented support for parallel tool execution (multiple tags in one generation).